### PR TITLE
Run shutdown-agents after tests complete

### DIFF
--- a/src/cognitect/test_runner.clj
+++ b/src/cognitect/test_runner.clj
@@ -104,4 +104,7 @@
   (let [args (parse-opts args cli-options)]
     (if (-> args :options :help)
       (help args)
-      (test (:options args)))))
+      (try
+        (test (:options args))
+        (finally
+          (shutdown-agents))))))


### PR DESCRIPTION
This prevents a delay between reporting test results and exiting the
process, if any tests have left thread pools running.