### PR TITLE
Support Clojure 1.6

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,5 +1,5 @@
 {:paths ["src"]
- :deps {org.clojure/tools.namespace {:mvn/version "0.3.0-alpha4"}
+ :deps {org.clojure/tools.namespace {:mvn/version "0.2.11"}
         org.clojure/tools.cli {:mvn/version "0.3.5"}
         org.clojure/clojure {:mvn/version "1.7.0"}}
  :aliases {:test {:extra-paths ["test" "dev"]

--- a/src/cognitect/test_runner.clj
+++ b/src/cognitect/test_runner.clj
@@ -70,7 +70,7 @@
 
 
 (defn- accumulate [m k v]
-  (update m k (fnil conj #{}) v))
+  (update-in m [k] (fnil conj #{}) v))
 
 (def cli-options
   [["-d" "--dir DIRNAME" "Name of the directory containing tests. Defaults to \"test\"."


### PR DESCRIPTION
org.clojure/tools.namespace 0.2.11 was the last version before `.cljc` files were introduced.

