### PR TITLE
Fix namespace filtering

### DIFF
--- a/src/cognitect/test_runner.clj
+++ b/src/cognitect/test_runner.clj
@@ -67,7 +67,7 @@
                   (map io/file)
                   (mapcat find/find-namespaces-in-dir))
         nses (filter (ns-filter options) nses)]
-    (println (format "\nRunning tests in %s" dirs))
+    (println (format "\nRunning tests from %s" (str/join ", " dirs)))
     (dorun (map require nses))
     (try
       (filter-vars! nses (var-filter options))

--- a/test/cognitect/test_runner_test.clj
+++ b/test/cognitect/test_runner_test.clj
@@ -1,0 +1,18 @@
+(ns cognitect.test-runner-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [cognitect.test-runner :as sut]))
+
+(deftest ns-filter-test
+  (testing "specific namespaces only"
+    (is (= ['foo]
+         (filter (#'sut/ns-filter {:namespace #{'foo}})
+                 ['foo 'foo-test 'foo-it-test]))))
+  (testing "regex namespaces only"
+    (is (= ['foo-it-test]
+           (filter (#'sut/ns-filter {:namespace-regex #{#"foo-it-test"}})
+                   ['foo 'foo-test 'foo-it-test]))))
+  (testing "specific and regex namespaces"
+    (is (= ['foo 'foo-it-test]
+           (filter (#'sut/ns-filter {:namespace #{'foo}
+                                     :namespace-regex #{#".*-it-test$"}})
+                   ['foo 'foo-test 'foo-it-test])))))


### PR DESCRIPTION
Reading the usage instruction some can assume that running test-runner with a specific namespace will run only this specific namespace, but it appears that you get a "default" namespace regex configuration as well. Pretty odd to see all your tests running.

Refactor the code to put all default configurations handling in a function.
- Set a default test dir when no test dirs specified
- Set a default namespace regex when no specific namespace or namespace regex specified.

Cheers