### PR TITLE
Add support for alternative outputs

### DIFF
--- a/src/cognitect/test_runner.clj
+++ b/src/cognitect/test_runner.clj
@@ -70,7 +70,10 @@
     (dorun (map require nses))
     (try
       (filter-vars! nses (var-filter options))
-      (eval `(~with-output (apply test/run-tests (quote ~nses))))
+      (binding [test/*test-out* (if (:output options)
+                                  (java.io.FileWriter. (:output options))
+                                  test/*test-out*)]
+        (eval `(~with-output (apply test/run-tests (quote ~nses)))))
       (finally
         (restore-vars! nses)))))
 
@@ -103,6 +106,7 @@
     :assoc-fn accumulate]
    ["-w" "--with-output SYMBOL" "Symbol indicating the with output wrapper."
     :parse-fn symbol]
+   ["-o" "--output STRING" "String indicating path to file to write output to."]
    ["-H" "--test-help" "Display this help message"]])
 
 (defn- help


### PR DESCRIPTION
My particular use-case is JUnit on CI systems, meaning two features are needed:

1. Wrapping `with-junit-output` around running the tests
2. Writing the output to a file for the CI to read

I have resolved both of these.

There is no standard parameterization system for clojure test output wrappers.
I think it is reasonable for users to create a macro which adds the parameters
they need, for parameterized output wrappers.