### PR TITLE
Return non-zero exit code when tests fail or error

### DIFF
--- a/src/cognitect/test_runner.clj
+++ b/src/cognitect/test_runner.clj
@@ -110,9 +110,9 @@
           (help args))
       (if (-> args :options :test-help)
         (help args)
-        (let [exit-code (try
-                          (let [{:keys [fail error]} (test (:options args))]
-                            (if (zero? (+ fail error)) 0 1))
-                          (finally
-                            (shutdown-agents)))]
-          (System/exit exit-code))))))
+        (try
+          (let [{:keys [fail error]} (test (:options args))]
+            (System/exit (if (zero? (+ fail error)) 0 1)))
+          (finally
+            ;; Only called if `test` raises an exception
+            (shutdown-agents)))))))

--- a/src/cognitect/test_runner.clj
+++ b/src/cognitect/test_runner.clj
@@ -110,7 +110,9 @@
           (help args))
       (if (-> args :options :test-help)
         (help args)
-        (try
-          (test (:options args))
-          (finally
-            (shutdown-agents)))))))
+        (let [exit-code (try
+                          (let [{:keys [fail error]} (test (:options args))]
+                            (if (zero? (+ fail error)) 0 1))
+                          (finally
+                            (shutdown-agents)))]
+          (System/exit exit-code))))))


### PR DESCRIPTION
Fixes https://github.com/cognitect-labs/test-runner/issues/9. Based on https://github.com/cognitect-labs/test-runner/pull/12, with the following differences:

- Returns non-zero exit code on either failure _or_ error. This is what CI environments expect, typically.
- ~Ensures `shutdown-agents` runs before exiting.~
  - ~This commit avoids a problem with PR #12, which calls `System/exit` before the finally block. That approach skips the finally block (1), unless `System/exit` is configured to throw a `SecurityException` (2), which I don't believe is the default in Clojure.~

1) https://stackoverflow.com/questions/65035/does-finally-always-execute-in-java
2) https://stackoverflow.com/questions/1410951/how-does-javas-system-exit-work-with-try-catch-finally-blocks