### PR TITLE
Respect --namespace filter without setting dummy --namespace-regex

### DIFF
--- a/src/cognitect/test_runner.clj
+++ b/src/cognitect/test_runner.clj
@@ -10,8 +10,9 @@
   [{:keys [namespace namespace-regex]}]
   (let [regexes (or namespace-regex [#".*\-test$"])]
     (fn [ns]
-      (or (and namespace (namespace ns))
-          (some #(re-matches % (name ns)) regexes)))))
+      (if namespace
+        (namespace ns)
+        (some #(re-matches % (name ns)) regexes)))))
 
 (defn- var-filter
   [{:keys [var include exclude]}]


### PR DESCRIPTION
Currently, if your project has two test namespaces, `a-test` and `b-test` if you call `clj -m test.runner --namespace b-test`, the tests from both namespaces will run. 

This is because the default ns regex `#"*-test"` allows both namespaces. One fix is to add a dummy regex to the command line: `clj -m test.runner --namespace b-test --namespace-regex zzz`. But that feels like a hack. This commit prevents the need for the hack.

One criticism of this fix is that it ignores `--namespace-regex` whenever `--namespace` is set. To me, this makes sense. But if you expect `--namespace-regex` and `--namespace` to apply simultaneously, let me know how you would like them to interact.