### PR TITLE
Fix --var option

### DIFF
--- a/src/cognitect/test_runner.clj
+++ b/src/cognitect/test_runner.clj
@@ -19,7 +19,8 @@
   (let [test-specific (if var
                         (set (map #(or (resolve %)
                                        (throw (ex-info (str "Could not resolve var: " %)
-                                                       {:symbol %})))))
+                                                       {:symbol %})))
+                                  var))
                         (constantly true))
         test-inclusion (if include
                          #((apply some-fn include) (meta %))


### PR DESCRIPTION
The set predicate used to filter by vars `#{ #'var.one #'var.two}}` was improperly constructed - it discarded the supplied var option entirely.  (map with one arg is a valid transducer)