### PR TITLE
Add before and after options

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:paths ["src"]
  :deps {org.clojure/tools.namespace {:mvn/version "0.2.11"}
         org.clojure/tools.cli {:mvn/version "0.3.5"}
-        org.clojure/clojure {:mvn/version "1.7.0"}}
+        org.clojure/clojure {:mvn/version "1.9.0"}}
  :aliases {:test {:extra-paths ["test" "dev"]
                   :extra-deps {org.clojure/test.check {:mvn/version "0.9.0"}}
                   :main-opts ["-m" "cognitect.test-runner"]}}

--- a/src/cognitect/test_runner.clj
+++ b/src/cognitect/test_runner.clj
@@ -70,7 +70,6 @@
   [s]
   (if (.startsWith s ":") (read-string s) (keyword s)))
 
-
 (defn- accumulate [m k v]
   (update-in m [k] (fnil conj #{}) v))
 
@@ -93,6 +92,12 @@
    ["-e" "--exclude KEYWORD" "Exclude tests with this metadata keyword."
     :parse-fn parse-kw
     :assoc-fn accumulate]
+   ["-b" "--before SYMBOL" "Symbol indicating the fully qualified name of a specific function to run before tests."
+    :parse-fn symbol
+    :assoc-fn accumulate]
+   ["-a" "--after SYMBOL" "Symbol indicating the fully qualified name of a specific function to run after tests."
+    :parse-fn symbol
+    :assoc-fn accumulate]
    ["-H" "--test-help" "Display this help message"]])
 
 (defn- help
@@ -101,6 +106,14 @@
   (println "clj -m" (namespace `help) "<options>\n")
   (println (:summary args))
   (println "\nAll options may be repeated multiple times for a logical OR effect."))
+
+(defn before [args]
+  (doseq [f (-> args :options :before)]
+    ((resolve f))))
+
+(defn after [args]
+  (doseq [f (-> args :options :after)]
+    ((resolve f))))
 
 (defn -main
   "Entry point for the test runner"
@@ -112,9 +125,12 @@
           (help args))
       (if (-> args :options :test-help)
         (help args)
-        (try
-          (let [{:keys [fail error]} (test (:options args))]
-            (System/exit (if (zero? (+ fail error)) 0 1)))
-          (finally
-            ;; Only called if `test` raises an exception
-            (shutdown-agents)))))))
+        (do (before args)
+            (try
+              (let [{:keys [fail error]} (test (:options args))]
+                (after args)
+                (System/exit (if (zero? (+ fail error)) 0 1)))
+              (finally
+                ;; Only called if `test` raises an exception
+                (after args)
+                (shutdown-agents))))))))


### PR DESCRIPTION
I wanted global fixtures that will setup before testing and teardown after testing. I generalized it as `-b[efore]` and `-a[fter]`. They take `Symbol indicating the fully qualified name of a specific function to run before/after tests.` I'm open to option naming and code review. I have `(after args)` in two places because of `(System/exit)` and it feels kind of gross.