### PR TITLE
Do not test namespaces without active tests

### DIFF
--- a/src/cognitect/test_runner.clj
+++ b/src/cognitect/test_runner.clj
@@ -44,19 +44,6 @@
                                 (assoc ::test (:test %))
                                 (dissoc :test))))))))
 
-(defn- filter-fixtures!
-  [nses]
-  (doseq [ns nses]
-    (let [public-vars (ns-publics ns)
-          test-vars (filter (fn [[_ var]] (:test (meta var))) public-vars)]
-      (when (empty? test-vars)
-        (alter-meta! (create-ns ns)
-                     (fn [m] (-> m
-                                 (assoc ::each-fixtures (:clojure.test/each-fixtures m))
-                                 (dissoc :clojure.test/each-fixtures)
-                                 (assoc ::once-fixtures (:clojure.test/once-fixtures m))
-                                 (dissoc :clojure.test/once-fixtures))))))))
-
 (defn- restore-vars!
   [nses]
   (doseq [ns nses]
@@ -66,19 +53,11 @@
                               (assoc :test (::test %))
                               (dissoc ::test)))))))
 
-(defn- restore-fixtures!
-  [nses]
-  (doseq [ns nses]
-    (let [ns-obj (create-ns ns)
-          ns-meta (meta ns-obj)]
-      (when-let [fixtures (::each-fixtures ns-meta)]
-        (alter-meta! ns-obj #(-> %
-                                 (assoc :clojure.test/each-fixtures fixtures)
-                                 (dissoc ::each-fixtures))))
-      (when-let [fixtures (::once-fixtures ns-meta)]
-        (alter-meta! ns-obj #(-> %
-                                 (assoc :clojure.test/once-fixtures fixtures)
-                                 (dissoc ::once-fixtures)))))))
+(defn- contains-tests?
+  "Check if a namespace contains some tests to be executed."
+  [ns]
+  (some (comp :test meta)
+        (-> ns ns-publics vals)))
 
 (defn test
   [options]
@@ -92,11 +71,9 @@
     (dorun (map require nses))
     (try
       (filter-vars! nses (var-filter options))
-      (filter-fixtures! nses)
-      (apply test/run-tests nses)
+      (apply test/run-tests (filter contains-tests? nses))
       (finally
-        (restore-vars! nses)
-        (restore-fixtures! nses)))))
+        (restore-vars! nses)))))
 
 (defn- parse-kw
   [^String s]


### PR DESCRIPTION
This fixes #33 in a more general way because it handles every test filtering feature not just `:vars`.

Moreover this implementation simplifies disabling useless fixtures described in #7.
