### PR TITLE
Change default namespace selector in readme.md to use :patterns

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -76,7 +76,7 @@ You may also supply any of the additional command line options:
 If neither :dirs or :nses is supplied, will use:
 
 ```
-  :nses [".*-test$"]
+  :patterns [".*-test$"]
 ```
 
 ### Invoke with `clojure -M` (clojure.main)


### PR DESCRIPTION
...since it is a regex. This threw me off for a bit until I read the options more thoroughly.