### PR TITLE
Support :only option for running single ns or var

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -2,7 +2,9 @@
  :deps {org.clojure/tools.namespace {:mvn/version "1.3.0"}
         org.clojure/tools.cli {:mvn/version "1.0.206"}
         org.clojure/clojure {:mvn/version "1.9.0"}}
- :aliases {:test {:extra-paths ["test"]
+ :aliases {:test {:extra-paths ["test"
+                                ;; tests ran with test runner to test behavior:
+                                "test-resources"]
                   :extra-deps {org.clojure/test.check {:mvn/version "1.1.1"}}
                   :main-opts ["-m" "cognitect.test-runner"]
                   :exec-fn cognitect.test-runner.api/test}}}

--- a/src/cognitect/test_runner.clj
+++ b/src/cognitect/test_runner.clj
@@ -59,9 +59,24 @@
   (some (comp :test meta)
         (-> ns ns-publics vals)))
 
+(defn- normalize-opts [opts]
+  (let [{:keys [namespace var only namespace-regex]} opts
+        [namespace var namespace-regex]
+        (if only
+          (if (qualified-symbol? only)
+            [nil #{only} nil]
+            [#{only} nil nil])
+          [namespace var namespace-regex])
+        opts (assoc opts
+                    :namespace namespace
+                    :var var
+                    :namespace-regex namespace-regex)]
+    opts))
+
 (defn test
   [options]
-  (let [dirs (or (:dir options)
+  (let [options (normalize-opts options)
+        dirs (or (:dir options)
                  #{"test"})
         nses (->> dirs
                   (map io/file)
@@ -102,6 +117,8 @@
    ["-e" "--exclude KEYWORD" "Exclude tests with this metadata keyword."
     :parse-fn parse-kw
     :assoc-fn accumulate]
+   ["-o" "--only SYMBOL" "Symbol indicating a specific namespace or var to test."
+    :parse-fn symbol]
    ["-H" "--test-help" "Display this help message"]])
 
 (defn- help

--- a/src/cognitect/test_runner/api.clj
+++ b/src/cognitect/test_runner/api.clj
@@ -4,13 +4,14 @@
     [cognitect.test-runner :as tr]))
 
 (defn- do-test
-  [{:keys [dirs nses patterns vars includes excludes]}]
+  [{:keys [dirs nses patterns vars includes excludes only]}]
   (let [adapted {:dir (when (seq dirs) (set dirs))
                  :namespace (when (seq nses) (set nses))
                  :namespace-regex (when (seq patterns) (map re-pattern patterns))
                  :var (when (seq vars) (set vars))
                  :include (when (seq includes) (set includes))
-                 :exclude (when (seq excludes) (set excludes))}]
+                 :exclude (when (seq excludes) (set excludes))
+                 :only only}]
     (tr/test adapted)))
 
 (defn test
@@ -22,6 +23,7 @@
   * :vars - coll of fully qualified symbols to run tests on
   * :includes - coll of test metadata keywords to include
   * :excludes - coll of test metadata keywords to exclude
+  * :only - a namespace or var to run tests on
 
   If neither :nses nor :patterns is supplied, use `:patterns [\".*-test$\"]`."
   [opts]

--- a/test-resources/acme/core_test.clj
+++ b/test-resources/acme/core_test.clj
@@ -1,0 +1,12 @@
+(ns acme.core-test
+  (:require [clojure.test :as t :refer [deftest is]]))
+
+(def expected (atom {}))
+
+(deftest foo-test
+  (swap! expected assoc :foo-test true)
+  (is true))
+
+(deftest bar-test
+  (swap! expected assoc :bar-test true)
+  (is true))

--- a/test/cognitect/test_runner_test.clj
+++ b/test/cognitect/test_runner_test.clj
@@ -1,7 +1,8 @@
 (ns cognitect.test-runner-test
   (:require
-    [clojure.test :refer :all]
-    [cognitect.test-runner :as tr]))
+   [acme.core-test :refer [expected]]
+   [clojure.test :refer :all]
+   [cognitect.test-runner :as tr]))
 
 (deftest ns-filters
   (are [ns-names ns-regexes available selected]
@@ -21,3 +22,12 @@
 
     ;; both
     '#{ns3} '#{#"ns1.*"} '[ns1-test ns2-test ns3 ns4] '[ns1-test ns3]))
+
+(deftest only-test
+  (tr/test {:only 'acme.core-test/bar-test
+            :dir ["test-resources"]})
+  (is (:bar-test @expected))
+  (is (not (:foo-test @expected)))
+  (tr/test {:only 'acme.core-test
+            :dir ["test-resources"]})
+  (is (:foo-test @expected)))


### PR DESCRIPTION
For people used to leiningen,  the `:only` option can be convenient to run either a whole namespace or a single test from a namespace.

Especially when paired with error reporting, where `:only foo.bar/baz-test` is printed when `foo.bar/baz-test` is failing, so you can copy paste that in the command line.

I did not include the printing in this PR, but can do another PR if that seems a good idea.